### PR TITLE
hammerhead: Unmatched lock in bluetooth_set_power

### DIFF
--- a/arch/arm/mach-msm/lge/board-8974-rfkill.c
+++ b/arch/arm/mach-msm/lge/board-8974-rfkill.c
@@ -190,6 +190,10 @@ static int bluetooth_set_power(void *data, bool blocked)
 		gpio_direction_output(GPIO_BT_RESET_N, 0);
 		printk(KERN_ERR "Bluetooth RESET LOW!!");
 	}
+
+#ifdef CONFIG_BCM4335BT
+	bcm_bt_unlock(lock_cookie_bt);
+#endif /* CONFIG_BCM4335BT */
 	return 0;
 }
 


### PR DESCRIPTION
Change-Id: I1b3cf8094f79b16f7944e28f0670bdbc146a89d6